### PR TITLE
fix: REF value needs to be a string

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -58,7 +58,7 @@ class PurchaseRequest extends AbstractRequest
 
         $data = [
             'AMT' => $this->getAmount(),
-            'REF' => $this->getTransactionId(),
+            'REF' => (string)$this->getTransactionId(),
         ];
 
         if ($token = $this->getToken()) {


### PR DESCRIPTION
Cast getTransactionId to string when setting REF